### PR TITLE
Revert "SEAndroid: Updated vold domain related policy"

### DIFF
--- a/common/file.te
+++ b/common/file.te
@@ -106,9 +106,6 @@ type ipacm_data_file, file_type;
 #Define the files written during the operation of mmi
 type mmi_data_file, file_type, data_file_type;
 
-#needed by vold
-type  proc_dirty_ratio, fs_type;
-
 # hbtp config file
 type hbtp_cfg_file, file_type;
 type hbtp_log_file, file_type;

--- a/common/genfs_contexts
+++ b/common/genfs_contexts
@@ -1,2 +1,1 @@
 genfscon proc /asound/card0/state u:object_r:proc_audiod:s0
-genfscon proc /proc/sys/vm/dirty_ratio  u:object_r:proc_dirty_ratio:s0

--- a/common/kernel.te
+++ b/common/kernel.te
@@ -1,1 +1,0 @@
-allow kernel block_device:blk_file r_file_perms;

--- a/common/vold.te
+++ b/common/vold.te
@@ -6,4 +6,3 @@ allow vold proc_sysrq:file rw_file_perms;
 allow vold self:capability sys_boot;
 allow vold cache_file:dir { write add_name };
 allow vold cache_file:file { write create open };
-allow vold proc_dirty_ratio:file rw_file_perms;

--- a/sepolicy.mk
+++ b/sepolicy.mk
@@ -88,7 +88,6 @@ BOARD_SEPOLICY_UNION += \
        wfd_app.te \
        mediaserver_test.te \
        hbtp.te \
-       kernel.te \
        vold.te
 
 -include device/qcom/sepolicy/$(TARGET_BOARD_PLATFORM)/Android.mk


### PR DESCRIPTION
This reverts commit 733050a425e9fbfeaa5f07bfcba0c30795ca7291.
This has an incorrect path, and doesn't belong here at all. Any
platform using UMS is affected by this

Change-Id: I067ba68a64c16406b787fefd97d6c6d9e0d41344